### PR TITLE
Possibly helpful SYS_PTRACE addition for docker-compose.yml

### DIFF
--- a/src/using-rbspy/index.md
+++ b/src/using-rbspy/index.md
@@ -12,10 +12,24 @@
 
 ## Containers
 
-If you want to profile a ruby program that's running in a container on Linux, be sure to add the `SYS_PTRACE` capability. For Docker containers, this can be done by adding a flag to the command when you launch the container:
+If you want to profile a ruby program that's running in a container on Linux, be sure to add the `SYS_PTRACE` capability.
+
+For Docker containers, this can be done by adding a flag to the command when you launch the container:
 
 ```
 docker run --cap-add=SYS_PTRACE ...
+```
+
+If your Docker containers start up through Docker Compose, you can add the flag to the relevant container(s) in `docker-compose.yml`:
+
+```
+services:
+  ruby_container_name:
+    ...
+    other_config_here
+    ...
+    cap_add:
+      - SYS_PTRACE
 ```
 
 If you're using Kubernetes, you can add the ptrace capability to a deployment like this:


### PR DESCRIPTION
I'm not very experienced with Docker but do have to fiddle with our config at work now and again. 

I was setting rbspy up last week and took a while to figure out that this is likely the best way to pass  `--cap-add=SYS_PTRACE` through to Docker containers that are started via Compose. Thought the info could help others in the future.

See [here](https://github.com/compose-spec/compose-spec/blob/master/spec.md#cap_add) for my source.

Let me know if you think this is too niche an addition or feel free to make/suggest a change.

FYI I don't think I even needed to add this to get tracing to work, as it looked to be working alright before I added this to my `docker-compose.yml`, but it's probably for the best to have it there.