### PR TITLE
Remove outdated mailing list reference

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -11,6 +11,6 @@
     - [Questions to ask](./profiling-guide/questions-to-ask.md)
     - [Benchmarking your code](./profiling-guide/benchmarking-your-code.md)
     - [Using flamegraphs](./profiling-guide/using-flamegraphs.md)
-- [Getting help](./getting-help.md)
+- [Reporting issues](./reporting-bugs.md)
 - [Contributing](./contributing.md)
 - [FAQ](./faq.md)

--- a/src/getting-help.md
+++ b/src/getting-help.md
@@ -1,7 +1,0 @@
-# Getting help
-
-The rbspy community, like the greater Ruby and Rust communities, is a helpful and welcoming place. If you need help using rbspy, here are a few options:
-
-- The mailing list! Email rbspy-users@googlegroups.com
-- Gitter chat room: http://gitter.im/rbspy/rbspy
-- If you think you've found a bug, [create an issue on GitHub](https://github.com/rbspy/rbspy/issues/new). You may want to search [open issues](https://github.com/rbspy/rbspy/issues) first, since someone else may have encountered the same bug.

--- a/src/reporting-bugs.md
+++ b/src/reporting-bugs.md
@@ -1,0 +1,5 @@
+# Reporting issues
+
+If you think you've found a bug, [create an issue on GitHub](https://github.com/rbspy/rbspy/issues/new).
+
+You may want to search [open issues](https://github.com/rbspy/rbspy/issues) first, since someone else may have encountered the same bug.


### PR DESCRIPTION
I noticed the [getting help page](https://rbspy.github.io/getting-help.html) refers to a couple of forums that I created aspirationally that I believe haven't been used in years (I don't know if the Google Group was ever used?)

This replaces it with a "Reporting issues" page which I think is more accurate to how the project actually works